### PR TITLE
feat: add property unassignment endpoint

### DIFF
--- a/src/controllers/property.controller.ts
+++ b/src/controllers/property.controller.ts
@@ -4,6 +4,7 @@ import { asyncHandler } from '../utils/asyncHandler.js';
 import { ApiError } from '../utils/ApiError.js';
 import {
   assignResearcherPropertyService,
+  unassignResearcherPropertyService,
   deletePropertyFileService,
   deletePropertyService,
   findOrUpdateProperty,
@@ -175,6 +176,27 @@ const assignResearcherProperty = asyncHandler(
       .status(200)
       .json(
         new ApiResponse(200, results, 'Researcher assignment process completed')
+      );
+  }
+);
+
+const unassignResearcherProperty = asyncHandler(
+  async (req: Request, res: Response) => {
+    const { propertyId, researcherId } = req.body;
+
+    const unassigned = await unassignResearcherPropertyService(
+      propertyId,
+      researcherId
+    );
+
+    res
+      .status(200)
+      .json(
+        new ApiResponse(
+          200,
+          { unassigned },
+          'Researcher unassigned from property successfully'
+        )
       );
   }
 );
@@ -414,6 +436,7 @@ export {
   addProperty,
   removeFiles,
   assignResearcherProperty,
+  unassignResearcherProperty,
   paginatedAssignedResearcherProperties,
   deleteProperty,
   getProperty,

--- a/src/routes/property.route.ts
+++ b/src/routes/property.route.ts
@@ -7,6 +7,7 @@ import {
   addPropertyValidation,
   assignedResearchersToPropertyValidation,
   assignResearcherPropertyValidation,
+  unassignResearcherPropertyValidation,
   deletePropertyValidation,
   propertyFilesValidation,
   researcherSubmittedReportsValidation,
@@ -16,6 +17,7 @@ import {
   addProperty,
   assignedResearchersToProperty,
   assignResearcherProperty,
+  unassignResearcherProperty,
   deleteProperty,
   getProperty,
   paginatedAssignedResearcherProperties,
@@ -127,6 +129,13 @@ router
     authMiddleware,
     roleCheck([ROLES.ADMIN]),
     assignResearcherProperty
+  )
+  .delete(
+    unassignResearcherPropertyValidation,
+    validateRequest,
+    authMiddleware,
+    roleCheck([ROLES.ADMIN]),
+    unassignResearcherProperty
   );
 
 router

--- a/src/utils/validations/propertyValidations.ts
+++ b/src/utils/validations/propertyValidations.ts
@@ -66,6 +66,19 @@ export const assignResearcherPropertyValidation = [
   body('assignDate').notEmpty().withMessage('Assign date is required!'),
 ];
 
+export const unassignResearcherPropertyValidation = [
+  body('propertyId')
+    .notEmpty()
+    .withMessage('Property Id is required!')
+    .isMongoId()
+    .withMessage('Property Id must be a valid MongoDB ObjectId.'),
+  body('researcherId')
+    .notEmpty()
+    .withMessage('Researcher Id is required!')
+    .isMongoId()
+    .withMessage('Researcher Id must be a valid MongoDB ObjectId.'),
+];
+
 export const deletePropertyValidation = [
   param('id')
     .notEmpty()


### PR DESCRIPTION
## Summary
- add service to unassign a researcher from a property
- expose unassignment handler and route with validation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeba9ee6248327aa8dfb96c7d62cb6