### PR TITLE
feat: add separate property note

### DIFF
--- a/src/controllers/landowner.controller.ts
+++ b/src/controllers/landowner.controller.ts
@@ -39,6 +39,7 @@ const addLandowner = asyncHandler(async (req: Request, res: Response) => {
     files,
     startDate,
     adminNote,
+    note,
   } = req.body;
 
   // Start a transaction
@@ -69,6 +70,7 @@ const addLandowner = asyncHandler(async (req: Request, res: Response) => {
         user._id,
         startDate,
         adminNote,
+        note,
         session
       );
 

--- a/src/controllers/property.controller.ts
+++ b/src/controllers/property.controller.ts
@@ -36,6 +36,7 @@ const addProperty = asyncHandler(async (req: Request, res: Response) => {
     files,
     startDate,
     adminNote,
+    note,
   } = req.body;
 
   const property = await findOrUpdateProperty(
@@ -45,7 +46,8 @@ const addProperty = asyncHandler(async (req: Request, res: Response) => {
     files,
     landownerId,
     startDate,
-    adminNote
+    adminNote,
+    note
   );
 
   if (!property) {
@@ -68,6 +70,7 @@ const updateProperty = asyncHandler(async (req: Request, res: Response) => {
     files,
     startDate,
     adminNote,
+    note,
   } = req.body;
 
   const { id } = req.params;
@@ -80,6 +83,7 @@ const updateProperty = asyncHandler(async (req: Request, res: Response) => {
     landownerId,
     startDate,
     adminNote,
+    note,
     id
   );
 
@@ -424,10 +428,10 @@ const getSingleBid = asyncHandler(async (req: Request, res: Response) => {
     .json(new ApiResponse(200, foundBid, 'Bid fetched successfully!'));
 });
 
-const updatePropertyAdminNote = asyncHandler(
+const updatePropertyNote = asyncHandler(
   async (req: Request, res: Response) => {
     const { id: propertyId } = req.params;
-    const { adminNote } = req.body;
+    const { note } = req.body;
     const { _id: userId } = req.user;
 
     // Find the property
@@ -440,7 +444,32 @@ const updatePropertyAdminNote = asyncHandler(
     // Set the user context for the middleware
     (property as any).__user = req.user;
 
-    // Update the admin note
+    // Update the note
+    property.note = note;
+    property.noteUpdatedBy = userId;
+
+    await property.save();
+
+    res.status(200).json(
+      new ApiResponse(200, property, 'Property note updated successfully')
+    );
+  }
+);
+
+const updatePropertyAdminNote = asyncHandler(
+  async (req: Request, res: Response) => {
+    const { id: propertyId } = req.params;
+    const { adminNote } = req.body;
+    const { _id: userId } = req.user;
+
+    const property = await Property.findById(propertyId);
+
+    if (!property) {
+      return res.status(404).json(new ApiError(404, 'Property not found!'));
+    }
+
+    (property as any).__user = req.user;
+
     property.adminNote = adminNote;
     property.adminNoteUpdatedBy = userId;
 
@@ -465,6 +494,7 @@ export {
   getSingleBid,
   toggleArchiveProperty,
   transferProperty,
+  updatePropertyNote,
   updatePropertyAdminNote,
   updateProperty,
   unnassignResearcherProperty,

--- a/src/interface/landowner.interface.ts
+++ b/src/interface/landowner.interface.ts
@@ -5,11 +5,16 @@ import { IProperty } from './property.interface.js';
 // Create a combined interface that avoids conflicts by being more specific
 export interface IAddLandownerParams
   extends Omit<IUser, 'note' | 'noteUpdatedBy'>,
-    Omit<IProperty, 'adminNote' | 'adminNoteUpdatedBy'> {
+    Omit<
+      IProperty,
+      'note' | 'noteUpdatedBy' | 'adminNote' | 'adminNoteUpdatedBy'
+    > {
   // Add back the note properties with more specific names to avoid conflicts
   userNote?: string;
+  propertyNote?: string;
   propertyAdminNote?: string;
   userNoteUpdatedBy?: string;
+  propertyNoteUpdatedBy?: string;
   propertyAdminNoteUpdatedBy?: string;
 }
 

--- a/src/interface/property.interface.ts
+++ b/src/interface/property.interface.ts
@@ -7,11 +7,13 @@ export interface IProperty {
   propertyName: string;
   propertyLocation: string;
   startDate: string;
-  adminNote: string;
+  note?: string;
+  adminNote?: string;
   propertySize: string | undefined;
   landowner: mongoose.Schema.Types.ObjectId;
   assignedResearchers: mongoose.Schema.Types.ObjectId[];
   archived: boolean;
+  noteUpdatedBy?: mongoose.Schema.Types.ObjectId;
   adminNoteUpdatedBy?: mongoose.Schema.Types.ObjectId;
 }
 
@@ -25,12 +27,17 @@ export interface IReports {
 }
 
 export interface IUpdateLandowner
-  extends Omit<IProperty, 'adminNote' | 'adminNoteUpdatedBy'>,
+  extends Omit<
+      IProperty,
+      'note' | 'noteUpdatedBy' | 'adminNote' | 'adminNoteUpdatedBy'
+    >,
     Omit<IUser, 'note' | 'noteUpdatedBy'> {
   // Add back the note properties with more specific names to avoid conflicts
   userNote?: string;
+  propertyNote?: string;
   propertyAdminNote?: string;
   userNoteUpdatedBy?: string;
+  propertyNoteUpdatedBy?: string;
   propertyAdminNoteUpdatedBy?: string;
 }
 

--- a/src/interface/university.interface.ts
+++ b/src/interface/university.interface.ts
@@ -5,11 +5,16 @@ import { IPReport } from './report.interface.js';
 
 export interface IAddUniversityParams
   extends Omit<IUser, 'note' | 'noteUpdatedBy'>,
-    Omit<IProperty, 'adminNote' | 'adminNoteUpdatedBy'> {
+    Omit<
+      IProperty,
+      'note' | 'noteUpdatedBy' | 'adminNote' | 'adminNoteUpdatedBy'
+    > {
   // Add back the note properties with more specific names to avoid conflicts
   userNote?: string;
+  propertyNote?: string;
   propertyAdminNote?: string;
   userNoteUpdatedBy?: string;
+  propertyNoteUpdatedBy?: string;
   propertyAdminNoteUpdatedBy?: string;
 }
 
@@ -32,14 +37,19 @@ export interface IUniversityReportBidsAggregatePaginationServiceParams
 }
 
 export interface IUpdateUniversity
-  extends Omit<IProperty, 'adminNote' | 'adminNoteUpdatedBy'>,
+  extends Omit<
+      IProperty,
+      'note' | 'noteUpdatedBy' | 'adminNote' | 'adminNoteUpdatedBy'
+    >,
     Omit<IPReport, 'note' | 'noteUpdatedBy'>,
     Omit<IUser, 'note' | 'noteUpdatedBy'> {
   // Add back the note properties with more specific names to avoid conflicts
   userNote?: string;
+  propertyNote?: string;
   propertyAdminNote?: string;
   reportNote?: string;
   userNoteUpdatedBy?: string;
+  propertyNoteUpdatedBy?: string;
   propertyAdminNoteUpdatedBy?: string;
   reportNoteUpdatedBy?: string;
 }

--- a/src/routes/property.route.ts
+++ b/src/routes/property.route.ts
@@ -11,6 +11,7 @@ import {
   propertyFilesValidation,
   researcherSubmittedReportsValidation,
   unnassignResearcherPropertyValidation,
+  updatePropertyNoteValidation,
   updatePropertyAdminNoteValidation,
 } from '../utils/validations/propertyValidations.js';
 import {
@@ -27,6 +28,7 @@ import {
   transferProperty,
   updateProperty,
   unnassignResearcherProperty,
+  updatePropertyNote,
   updatePropertyAdminNote,
 } from '../controllers/property.controller.js';
 import propertyBidsRouter from './propertyBids.route.js';
@@ -149,6 +151,16 @@ router
     authMiddleware,
     roleCheck([ROLES.ADMIN]),
     updatePropertyAdminNote
+  );
+
+router
+  .route('/:id/note')
+  .patch(
+    updatePropertyNoteValidation,
+    validateRequest,
+    authMiddleware,
+    roleCheck([ROLES.LANDOWNER, ROLES.ADMIN]),
+    updatePropertyNote
   );
 
 export default router;

--- a/src/services/landowner.service.ts
+++ b/src/services/landowner.service.ts
@@ -166,6 +166,8 @@ const landownerAggregatePaginationService = async ({
               propertyLocation: 1,
               startDate: 1,
               propertySize: 1,
+              note: 1,
+              noteUpdatedBy: 1,
               ...(roles === ROLES.ADMIN
                 ? { adminNote: 1, adminNoteUpdatedBy: 1 }
                 : {}),
@@ -391,6 +393,8 @@ const landownerPropertyAggregatePaginationService = async ({
         archived: 1,
         propertyLocation: 1,
         propertySize: 1,
+        note: 1,
+        noteUpdatedBy: 1,
         ...(roles === ROLES.ADMIN
           ? { adminNote: 1, adminNoteUpdatedBy: 1 }
           : {}),
@@ -672,6 +676,8 @@ const landownerPropertyBidsPaginationService = async ({
               startDate: 1,
               landowner: 1,
               assignedResearchers: 1,
+              note: 1,
+              noteUpdatedBy: 1,
               ...(roles === ROLES.ADMIN
                 ? { adminNote: 1, adminNoteUpdatedBy: 1 }
                 : {}),

--- a/src/services/property.service.ts
+++ b/src/services/property.service.ts
@@ -16,6 +16,7 @@ const findOrUpdatePropertySession = async (
   userId: mongoose.Schema.Types.ObjectId | string,
   startDate: string,
   adminNote: string | undefined = undefined,
+  note: string | undefined = undefined,
   session: ClientSession
 ) => {
   let property = await Property.findOne({
@@ -32,6 +33,7 @@ const findOrUpdatePropertySession = async (
       propertySize,
       startDate,
       ...(adminNote ? { adminNote } : {}),
+      ...(note ? { note } : {}),
     });
 
     // Ensure validation is skipped for required fields during updates
@@ -48,6 +50,7 @@ const findOrUpdatePropertySession = async (
           landowner: userId,
           startDate,
           ...(adminNote ? { adminNote } : {}),
+          ...(note ? { note } : {}),
         },
       ],
       { session }
@@ -91,6 +94,7 @@ const findOrUpdateProperty = async (
   userId: mongoose.Schema.Types.ObjectId | string,
   startDate: string,
   adminNote: string | undefined = undefined,
+  note: string | undefined = undefined,
   propertyId: mongoose.Schema.Types.ObjectId | string | null = null
 ) => {
   const findCondition = propertyId
@@ -123,6 +127,7 @@ const findOrUpdateProperty = async (
         propertySize,
         startDate,
         ...(adminNote ? { adminNote } : {}),
+        ...(note ? { note } : {}),
       });
 
       await property.save({ session, validateModifiedOnly: true });
@@ -137,6 +142,7 @@ const findOrUpdateProperty = async (
           landowner: userId,
           startDate,
           ...(adminNote ? { adminNote } : {}),
+          ...(note ? { note } : {}),
         },
       ],
       { session }
@@ -468,6 +474,8 @@ const getPropertyService = async (propertyId: string, roles?: string) => {
         propertySize: 1,
         landowner: 1,
         startDate: 1,
+        note: 1,
+        noteUpdatedBy: 1,
         ...(roles === ROLES.ADMIN
           ? { adminNote: 1, adminNoteUpdatedBy: 1 }
           : {}),
@@ -630,7 +638,7 @@ const getPaginatedAssignedResearcherProperties = async (
                     email: 1,
                     phone: 1,
                     ...(roles === ROLES.ADMIN
-                      ? { adminNote: 1, adminNoteUpdatedBy: 1 }
+                    ? { note: 1, noteUpdatedBy: 1 }
                       : {}),
                   },
                 },
@@ -650,6 +658,8 @@ const getPaginatedAssignedResearcherProperties = async (
               propertyLocation: 1,
               propertySize: 1,
               startDate: 1,
+              note: 1,
+              noteUpdatedBy: 1,
               ...(roles === ROLES.ADMIN
                 ? { adminNote: 1, adminNoteUpdatedBy: 1 }
                 : {}),
@@ -786,6 +796,8 @@ const getPaginatedPropertiesAssignedToResearcher = async (
               propertyLocation: 1,
               propertySize: 1,
               startDate: 1,
+              note: 1,
+              noteUpdatedBy: 1,
               ...(roles === ROLES.ADMIN
                 ? { adminNote: 1, adminNoteUpdatedBy: 1 }
                 : {}),
@@ -842,6 +854,8 @@ const getPaginatedPropertiesAssignedToResearcher = async (
                 propertyLocation: '$property.propertyLocation',
                 propertySize: '$property.propertySize',
                 startDate: '$property.startDate',
+                note: '$property.note',
+                noteUpdatedBy: '$property.noteUpdatedBy',
                 ...(roles === ROLES.ADMIN
                   ? {
                       adminNote: '$property.adminNote',
@@ -923,6 +937,8 @@ const getPaginatedResearcherReportsOnProperty = async (
               propertySize: 1,
               startDate: 1,
               landowner: 1,
+              note: 1,
+              noteUpdatedBy: 1,
               ...(roles === ROLES.ADMIN
                 ? { adminNote: 1, adminNoteUpdatedBy: 1 }
                 : {}),
@@ -1003,6 +1019,8 @@ const getPaginatedResearcherReportsOnProperty = async (
         propertySize: '$property.propertySize',
         landowner: '$property.landowner',
         startDate: '$property.startDate',
+        note: '$property.note',
+        noteUpdatedBy: '$property.noteUpdatedBy',
         ...(roles === ROLES.ADMIN
           ? {
               adminNote: '$property.adminNote',
@@ -1121,6 +1139,8 @@ const getAllPaginatedPropertiesService = async (
         propertySize: 1,
         landowner: 1,
         startDate: 1,
+        note: 1,
+        noteUpdatedBy: 1,
         ...(roles === ROLES.ADMIN
           ? { adminNote: 1, adminNoteUpdatedBy: 1 }
           : {}),

--- a/src/utils/validations/propertyValidations.ts
+++ b/src/utils/validations/propertyValidations.ts
@@ -21,6 +21,11 @@ export const addPropertyValidation = [
     .trim()
     .isLength({ min: 3 })
     .withMessage('Property Size must be at least 3 characters long'),
+  body('note')
+    .optional()
+    .trim()
+    .isLength({ min: 1, max: 1000 })
+    .withMessage('Note must be between 1 and 1000 characters long'),
   body('adminNote')
     .optional()
     .trim()
@@ -146,6 +151,29 @@ export const getSingleBidValidation = [
     .withMessage('Bid Id is required!')
     .isMongoId()
     .withMessage('Bid Id must be a valid MongoDB ObjectId.'),
+];
+
+export const updatePropertyNoteValidation = [
+  param('id')
+    .notEmpty()
+    .withMessage('Property Id is required!')
+    .isMongoId()
+    .withMessage('Property Id must be a valid MongoDB ObjectId.')
+    .custom(async (value) => {
+      const property = await Property.findById(value);
+
+      if (!property) {
+        return Promise.reject('Property not found!');
+      }
+
+      return true;
+    }),
+  body('note')
+    .notEmpty()
+    .withMessage('Note is required!')
+    .trim()
+    .isLength({ min: 1, max: 1000 })
+    .withMessage('Note must be between 1 and 1000 characters long'),
 ];
 
 export const updatePropertyAdminNoteValidation = [


### PR DESCRIPTION
## Summary
- support both general and admin notes on properties
- surface note info in property APIs and add endpoints to update each note type
- validate note fields and restrict admin note changes to admins

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca373ecc8327bb26d6716ffd642c