### PR TITLE
Allow researchers to submit new bids after approval

### DIFF
--- a/src/controllers/researcher.controller.ts
+++ b/src/controllers/researcher.controller.ts
@@ -354,15 +354,24 @@ const placeBidResearch = asyncHandler(async (req: Request, res: Response) => {
       .json(new ApiResponse(400, null, `Property does not exist!`));
   }
 
-  const [findBid] = await Bids.find({
+  const existingActiveBid = await Bids.findOne({
     researcher: userId,
     property: propertyId,
-  });
+    status: { $ne: PROPOSAL_STATUS.APPROVED },
+  })
+    .sort({ createdAt: -1 })
+    .lean();
 
-  if (findBid) {
+  if (existingActiveBid) {
     return res
       .status(201)
-      .json(new ApiResponse(400, findBid, `Bid already exists!`));
+      .json(
+        new ApiResponse(
+          400,
+          existingActiveBid,
+          `An active bid already exists for this property!`
+        )
+      );
   }
 
   const filePayload = files.map((file: TUploadedFileType) => ({


### PR DESCRIPTION
## Summary
- allow researchers to submit a new proposal on the same property once all previous proposals have been approved
- return a clearer error response when a researcher already has an active proposal for the property

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15e65274c8327871ee758f51e3b66