### PR TITLE
Fix property updates and report submissions

### DIFF
--- a/src/controllers/researcher.controller.ts
+++ b/src/controllers/researcher.controller.ts
@@ -452,14 +452,14 @@ const removeBidResearch = asyncHandler(async (req: Request, res: Response) => {
 
 const addReports = asyncHandler(async (req: Request, res: Response) => {
   const { id: researcherId } = req.user;
-  const { property, files, name, description } = req.body;
+  const { property, files = [], name, description } = req.body;
 
   const [researcherPermission] = await Bids.find({
     researcher: researcherId,
     property,
   });
 
-  const filePayload = files.map((file: TUploadedFileType) => ({
+  const filePayload = (files as TUploadedFileType[]).map((file) => ({
     name: file.filename,
     url: file.path,
     type: file.mimetype,
@@ -544,9 +544,9 @@ System Notification`
 
 const updateReport = asyncHandler(async (req: Request, res: Response) => {
   const { id: reportId } = req.params;
-  const { files, name, description } = req.body;
+  const { files = [], name, description } = req.body;
 
-  const filePayload = files.map((file: TUploadedFileType) => ({
+  const filePayload = (files as TUploadedFileType[]).map((file) => ({
     name: file.filename,
     url: file.path,
     type: file.mimetype,
@@ -554,9 +554,11 @@ const updateReport = asyncHandler(async (req: Request, res: Response) => {
   }));
 
   // Dynamically build the update object
-  const updatePayload: any = {
-    $push: { files: filePayload }, // Always push new files
-  };
+  const updatePayload: any = {};
+
+  if (filePayload.length) {
+    updatePayload.$push = { files: { $each: filePayload } };
+  }
 
   // Add `name` to the payload only if it is provided
   if (name !== undefined && name.trim() !== '') {
@@ -566,6 +568,12 @@ const updateReport = asyncHandler(async (req: Request, res: Response) => {
   // Add `description` to the payload only if it is provided
   if (description !== undefined && description.trim() !== '') {
     updatePayload.description = description.trim();
+  }
+
+  if (!Object.keys(updatePayload).length) {
+    return res
+      .status(400)
+      .json(new ApiError(400, 'Nothing to update in the report!'));
   }
 
   const addedPropertyFile = await Reports.findOneAndUpdate(

--- a/src/services/property.service.ts
+++ b/src/services/property.service.ts
@@ -27,14 +27,16 @@ const findOrUpdatePropertySession = async (
   let uploadedPropertyFiles = null;
 
   if (property) {
-    property.set({
-      propertyName,
-      propertyLocation,
-      propertySize,
-      startDate,
+    const updateData: Record<string, any> = {
+      ...(propertyName !== undefined ? { propertyName } : {}),
+      ...(propertyLocation !== undefined ? { propertyLocation } : {}),
+      ...(propertySize !== undefined ? { propertySize } : {}),
+      ...(startDate !== undefined ? { startDate } : {}),
       ...(adminNote ? { adminNote } : {}),
       ...(note ? { note } : {}),
-    });
+    };
+
+    property.set(updateData);
 
     // Ensure validation is skipped for required fields during updates
     await property.save({ session, validateModifiedOnly: true });
@@ -121,32 +123,34 @@ const findOrUpdateProperty = async (
 
   try {
     if (property) {
-      property.set({
-        propertyName,
-        propertyLocation,
-        propertySize,
-        startDate,
+      const updateData: Record<string, any> = {
+        ...(propertyName !== undefined ? { propertyName } : {}),
+        ...(propertyLocation !== undefined ? { propertyLocation } : {}),
+        ...(propertySize !== undefined ? { propertySize } : {}),
+        ...(startDate !== undefined ? { startDate } : {}),
         ...(adminNote ? { adminNote } : {}),
         ...(note ? { note } : {}),
-      });
+      };
+
+      property.set(updateData);
 
       await property.save({ session, validateModifiedOnly: true });
       property.isNew = false;
     } else {
       const [createdProperty] = await Property.create(
         [
-        {
-          propertyName,
-          propertyLocation,
-          propertySize,
-          landowner: userId,
-          startDate,
-          ...(adminNote ? { adminNote } : {}),
-          ...(note ? { note } : {}),
-        },
-      ],
-      { session }
-    );
+          {
+            propertyName,
+            propertyLocation,
+            propertySize,
+            landowner: userId,
+            startDate,
+            ...(adminNote ? { adminNote } : {}),
+            ...(note ? { note } : {}),
+          },
+        ],
+        { session }
+      );
       property = createdProperty;
       property.isNew = true; // Flag for response
     }


### PR DESCRIPTION
## Summary
- avoid overwriting property fields with undefined values during updates while keeping transactions intact
- allow researchers to submit or update reports without files and block empty report updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e346e70388327a2e51acf61cff1a5)